### PR TITLE
Add content-length header, send 1mb chunks

### DIFF
--- a/src/p4d.js
+++ b/src/p4d.js
@@ -1,15 +1,24 @@
 import { auth, refresh } from './auth'
 
-import { createReadStream } from 'fs'
+import { createReadStream, statSync } from 'fs'
 import { request } from 'https'
+import { basename } from 'path'
 
 const FormData = require('form-data')
 
 async function doit (gameId, filename, name, notes, config) {
   return new Promise((resolve, reject) => {
+    const stat = statSync(filename)
+
     const form = new FormData()
 
-    form.append('file', createReadStream(filename))
+    form.append('file', createReadStream(filename, {
+      highWaterMark: 1024 * 1024 // 1mb
+    }), {
+      filepath: basename(filename),
+      knownLength: stat.size,
+      contentType: 'application/zip'
+    })
     if (name !== filename) {
       form.append('label', name)
     }


### PR DESCRIPTION
Try to prevent EPIPE errors by sending bigger chunks and including a Content-Length header. By default `fs.createReadStream` uses 16kb chunks which could result in a lot of chunks for big zipfiles.