### PR TITLE
Bypass Cloudflare for uploads

### DIFF
--- a/src/p4d.ts
+++ b/src/p4d.ts
@@ -45,11 +45,12 @@ async function doit (gameId: string, filename: string, name: string, notes: stri
     const buffer = form.getBuffer()
     const path = process.env.API_PATH ?? `/games/${gameId}/versions`
     const req = request({
-      hostname: 'devs-api.poki.io',
+      hostname: '34.111.107.149',
       port: 443,
       path,
       method: 'POST',
       headers: {
+        Host: 'devs-api.poki.io',
         Authorization: `${config.access_type ?? 'Bearer'} ${config.access_token ?? ''}`,
         'Content-Length': buffer.length,
         'User-Agent': 'poki-cli',


### PR DESCRIPTION
Cloudflare blocks uploads from certain IPs with sometimes 520 and sometimes 502 randomly. Disabling all protection doesn't seem to fix the issue. No workaround other than this could be found.